### PR TITLE
Revert "remove migration	"

### DIFF
--- a/db/migrate/20160416123534_add_fields_to_links.rb
+++ b/db/migrate/20160416123534_add_fields_to_links.rb
@@ -1,0 +1,6 @@
+class AddFieldsToLinks < ActiveRecord::Migration
+  def change
+    add_column :links, :mimetype, :string
+    add_column :links, :size, :integer
+  end
+end


### PR DESCRIPTION
This reverts commit 32d358d3797b030c9ba1d705dae0aa57c9d0cf56.

Replace removed migration to add fields to links. The removal of these fields was causing CasesController show spec to fail (no such field for hidden field for links on cases show page)